### PR TITLE
PR 5 - Etapa 6: Otimização de Infraestrutura, Docker e Pipeline de CI/CD

### DIFF
--- a/.github/workflows/experimento-ci-cd.yml
+++ b/.github/workflows/experimento-ci-cd.yml
@@ -1,100 +1,63 @@
-# Nome do workflow
 name: experimento-ci-cd
 
-# Evento que aciona o workflow: toda vez que for criado um Pull Request para a branch main
 on:
   pull_request:
     branches:
       - main
 
-# Definição dos jobs (tarefas) que serão executadas
 jobs:
-
-  # Primeiro job: Executar testes unitários
   unit-test:
-    runs-on: ubuntu-latest  # Define o sistema operacional usado no runner (Ubuntu na versão mais recente)
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout do código
-        uses: actions/checkout@v4  # Faz o download do repositório no runner
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: |
+          cd backend
+          npm ci
+          npm test -- --coverage
 
-      - name: Instalar dependências do backend
-        run: |
-          cd backend              # Acessa a pasta do backend
-          npm install             # Instala as dependências do Node.js
-
-      - name: Executar testes unitários com Jest
-        run: |
-          cd backend              # Acessa novamente a pasta do backend
-          npm test -- --coverage  # Executa os testes e gera relatório de cobertura
-
-  # Segundo job: Build (construção) das imagens Docker
   build:
-    needs: unit-test  # Esse job só será executado após o job 'unit-test' ser concluído com sucesso
+    needs: unit-test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout do código
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v2
+      - run: docker compose build
 
-      - name: Configurar Docker Buildx
-        uses: docker/setup-buildx-action@v2  # Habilita a ferramenta Buildx do Docker para builds mais avançados
-
-      - name: Configurar Docker QEMU
-        uses: docker/setup-qemu-action@v2  # Permite builds multiplataforma usando emulação (útil em CI)
-
-      - name: Build das imagens Docker
-        run: docker compose build  # Executa o build das imagens definidas no docker-compose.yml
-
-  # Terceiro job: Subir os containers temporariamente para testes básicos de integração
   up-containers:
-    needs: build  # Esse job depende do job 'build'
+    needs: build
     runs-on: ubuntu-latest
-
-    # Definição de variáveis de ambiente necessárias para o backend e banco
     env:
       POSTGRES_DB: adote_facil
       POSTGRES_HOST: adote-facil-postgres
-      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}  # Usuário do banco, vindo dos segredos do repositório
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}  # Senha do banco
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       POSTGRES_PORT: 5432
       POSTGRES_CONTAINER_PORT: 6500
-
     steps:
-      - name: Checkout do código
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - run: |
+          echo "POSTGRES_DB=${{ env.POSTGRES_DB }}" > ./backend/.env
+          echo "POSTGRES_HOST=${{ env.POSTGRES_HOST }}" >> ./backend/.env
+          echo "POSTGRES_USER=${{ env.POSTGRES_USER }}" >> ./backend/.env
+          echo "POSTGRES_PASSWORD=${{ env.POSTGRES_PASSWORD }}" >> ./backend/.env
+          echo "POSTGRES_PORT=${{ env.POSTGRES_PORT }}" >> ./backend/.env
+          echo "POSTGRES_CONTAINER_PORT=${{ env.POSTGRES_CONTAINER_PORT }}" >> ./backend/.env
+          cp ./backend/.env ./frontend/.env
+      - run: |
+          docker compose up -d --wait
+          docker compose down
 
-      - name: Criar arquivo .env
-        working-directory: ./backend  # Define o diretório de trabalho para esse passo
-        run: |
-          # Gera o arquivo .env com as variáveis definidas acima
-          echo "POSTGRES_DB=${{ env.POSTGRES_DB }}" > .env
-          echo "POSTGRES_HOST=${{ env.POSTGRES_HOST }}" >> .env
-          echo "POSTGRES_USER=${{ env.POSTGRES_USER }}" >> .env
-          echo "POSTGRES_PASSWORD=${{ env.POSTGRES_PASSWORD }}" >> .env
-          echo "POSTGRES_PORT=${{ env.POSTGRES_PORT }}" >> .env
-          echo "POSTGRES_CONTAINER_PORT=${{ env.POSTGRES_CONTAINER_PORT }}" >> .env
-
-      - name: Subir containers com Docker Compose
-        working-directory: ./backend
-        run: |
-          docker compose up -d     # Sobe os containers em segundo plano
-          sleep 10                 # Aguarda alguns segundos para garantir que os serviços subam
-          docker compose down      # Encerra os containers após o teste
-
-  # Quarto job: Geração e entrega do artefato do projeto
   delivery:
-    needs: build  # Esse job também depende do job 'build'
+    needs: build
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout do código
-        uses: actions/checkout@v4
-
-      - name: Gerar arquivo ZIP do projeto completo
-        run: zip -r adote-facil-projeto.zip . -x '*.git*' '*.github*' 'node_modules/*'
-        # Compacta todos os arquivos do repositório, exceto pastas desnecessárias como .git, .github e node_modules
-
-      - name: Upload do artefato
-        uses: actions/upload-artifact@v4
+      - uses: actions/checkout@v4
+      - run: zip -r adote-facil-projeto.zip . -x '*.git*' '*.github*' 'node_modules/*'
+      - uses: actions/upload-artifact@v4
         with:
-          name: adote-facil-projeto  # Nome do artefato que aparecerá na aba de artefatos da execução
-          path: adote-facil-projeto.zip  # Caminho do arquivo que será enviado
+          name: adote-facil-projeto
+          path: adote-facil-projeto.zip

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,15 +6,15 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 
-RUN npm install
+RUN npm ci
 
 COPY . .
 
 RUN npm run generate
 
-RUN npm run test
-
 RUN npm run build
+
+RUN npm prune --production
 
 EXPOSE 8080
 

--- a/diagramas/atividades.plantuml
+++ b/diagramas/atividades.plantuml
@@ -1,0 +1,22 @@
+@startuml
+title Diagrama de Atividades - Cadastro de Novo Animal
+
+!theme spacelab
+
+start
+:Usuário clica em 'Anunciar Animal';
+:Sistema exibe formulário de cadastro;
+:Usuário preenche os dados do animal;
+:Usuário faz upload de até 5 imagens;
+
+if (Dados são válidos no frontend? (validação com Zod)) then (sim)
+  :Frontend envia requisição POST para a rota /animals;
+  :Backend recebe dados e imagens (usando Multer);
+  :Backend salva informações no banco de dados (usando Prisma);
+  :Sistema retorna mensagem de "Anúncio criado com sucesso";
+else (não)
+  :Sistema exibe mensagens de erro no formulário;
+endif
+
+stop
+@enduml

--- a/diagramas/classes.plantuml
+++ b/diagramas/classes.plantuml
@@ -1,0 +1,46 @@
+@startuml
+title Diagrama de Classes - Adote Fácil
+
+!theme spacelab
+
+class Usuario {
+  + nome: String
+  + email: String
+  - senha_hash: String
+  --
+  + criar()
+  + atualizar()
+  + autenticar()
+}
+
+class Animal {
+  + nome: String
+  + genero: String
+  + tipo: String
+  + status: String
+  + imagens: Array[String]
+  --
+  + criarAnuncio()
+  + atualizarStatus()
+}
+
+class Chat {
+  --
+  + criar()
+  + listarMensagens()
+}
+
+class Mensagem {
+  + conteudo: String
+  + dataEnvio: DateTime
+  --
+  + enviar()
+}
+
+
+Usuario "1" -- "*" Animal : "publica"
+Usuario "2..*" -- "1" Chat : "participa em"
+Chat "1" -- "*" Mensagem : "contém"
+Usuario "1" -- "*" Mensagem : "envia"
+
+@enduml

--- a/diagramas/componentes.plantuml
+++ b/diagramas/componentes.plantuml
@@ -1,0 +1,14 @@
+@startuml
+
+title Diagrama de Componentes - Adote Fácil
+
+!theme spacelab
+
+component [Frontend\n(Next.js)] as fe
+component [Backend\n(Node.js/Express)] as be
+database "Banco de Dados\n(PostgreSQL)" as db
+
+fe ..> be : "consome API"
+be ..> db : "persiste dados"
+
+@enduml

--- a/diagramas/sequencia.plantuml
+++ b/diagramas/sequencia.plantuml
@@ -1,0 +1,33 @@
+@startuml
+title Diagrama de Sequência - Autenticação de Usuário
+
+!theme spacelab
+
+actor Usuário
+participant "Frontend (React)" as FE
+participant "Backend (Express)" as BE
+database "Banco de Dados (PostgreSQL)" as DB
+
+Usuário -> FE : Preenche e-mail e senha
+Usuário -> FE : Clica em "Entrar"
+activate FE
+
+FE -> BE : POST /login com {email, senha}
+activate BE
+
+BE -> DB : SELECT * FROM usuarios WHERE email = ?
+activate DB
+DB --> BE : Retorna dados do usuário (ou nulo)
+deactivate DB
+
+BE -> BE : Compara hash da senha enviada com a do banco
+BE -> BE : Gera Token JWT
+
+BE --> FE : Retorna { token, dadosDoUsuario }
+deactivate BE
+
+FE -> FE : Armazena o token no navegador
+FE -> Usuário : Redireciona para a página principal
+deactivate FE
+
+@enduml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   adote-facil-postgres:
     image: postgres:14-alpine
     container_name: 'adote-facil-postgres'
+    restart: unless-stopped
     env_file:
       - ./backend/.env
     environment:
@@ -26,14 +27,16 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: 'adote-facil-backend'
+    restart: unless-stopped
     ports:
       - "8080:8080"
+    env_file:
+      - ./backend/.env
     environment:
       - NODE_ENV=production
     depends_on:
       adote-facil-postgres:
         condition: service_healthy
-    command: sh -c "until nc -z adote-facil-postgres 5432; do echo 'Waiting for postgres...'; sleep 1; done; npm start"
     networks:
       - adote-facil-network
 
@@ -42,8 +45,11 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     container_name: 'adote-facil-frontend'
+    restart: unless-stopped
     ports:
       - "3000:3000"
+    env_file:
+      - ./frontend/.env
     environment:
       - NODE_ENV=production
     depends_on:

--- a/documentacao/devops.md
+++ b/documentacao/devops.md
@@ -1,0 +1,9 @@
+# Análise e Sugestões DevOps
+
+## 1. Refatoração do Docker Compose (`docker-compose.yml`)
+
+As seguintes alterações foram implementadas:
+
+* **Remoção de script de espera:** O serviço `adote-facil-backend` utilizava um script manual, como `command: sh -c "until nc -z..."` para aguardar o banco de dados. Removemos isso, pois o banco já possui um `healthcheck` configurado e o backend utiliza a diretiva nativa `depends_on: condition: service_healthy`, o que torna a espera via script redundante e ineficiente.
+* **Injeção Explícita de Variáveis de Ambiente:** Adicionamos a diretiva `env_file` nos serviços `adote-facil-backend` e `adote-facil-frontend`. É uma boa prática que o orquestrador de contêineres seja o responsável por injetar as variáveis de ambiente, garantindo que o contêiner seja agnóstico ao ambiente em que roda.
+* **Políticas de Resiliência:** Implementamos a política `restart: unless-stopped` em todos os serviços. Isso garante alta disponibilidade, reiniciando os contêineres automaticamente em caso de falhas ou reinicialização do host.

--- a/documentacao/devops.md
+++ b/documentacao/devops.md
@@ -15,3 +15,11 @@ O Dockerfile original do backend apresentava alguns anti-padrões de CI/CD e emp
 * **Remoção da execução de testes na build:** A instrução `RUN npm run test` foi removida. A responsabilidade de executar testes e barrar código quebrado pertence à esteira de Integração Contínua (CI), e não ao artefato de build. Isso reduz o tempo de empacotamento e separa as responsabilidades.
 * **Uso de Instalação Determinística:** Substituição do `npm install` por `npm ci`. Isso garante que o Docker instale exatamente as versões das dependências "lockadas" no `package-lock.json`, evitando quebra de builds por atualizações inesperadas de pacotes.
 * **Limpeza de dependências de desenvolvimento:** Adição do comando `RUN npm prune --production` após a etapa de compilação. Isso remove da imagem final bibliotecas usadas apenas em tempo de desenvolvimento, reduzindo o tamanho do contêiner.
+
+## 3. Otimização do Dockerfile do Frontend (`frontend/Dockerfile`)
+
+o Dockerfile do frontend foi otimizado para produção:
+
+* **Instalação Determinística:** Substituição de `npm install` por `npm ci` para garantir reprodutibilidade das builds.
+
+Adição do comando `RUN npm prune --production` logo após o passo de build. Removê-las da imagem final reduz drasticamente o peso do contêiner e melhora a segurança e o tempo de deploy.

--- a/documentacao/devops.md
+++ b/documentacao/devops.md
@@ -23,3 +23,10 @@ o Dockerfile do frontend foi otimizado para produção:
 * **Instalação Determinística:** Substituição de `npm install` por `npm ci` para garantir reprodutibilidade das builds.
 
 Adição do comando `RUN npm prune --production` logo após o passo de build. Removê-las da imagem final reduz drasticamente o peso do contêiner e melhora a segurança e o tempo de deploy.
+
+
+## 4. Melhorias no Pipeline de CI/CD (`.github/workflows/experimento-ci-cd.yml`)
+
+* **Controle de Versão do Ambiente:** Inclusão do passo `actions/setup-node@v4` para fixar a versão do Node.js (v20), evitando incompatibilidades entre o ambiente do runner e o contêiner de produção.
+* **Correção de Contexto de Execução:** O diretório de trabalho (working directory) dos jobs de integração foi ajustado para a raiz do repositório, refletindo a nova localização do `docker-compose.yml`. A injeção de variáveis `.env` também foi corrigida para abastecer ambos os serviços (backend e frontend).
+* **Espera Inteligente de Contêineres:** Remoção do anti-padrão de temporização manual `sleep 10` no job de testes de integração. Foi implementada a flag `--wait` no `docker compose up`, que aproveita os `healthchecks` nativos dos serviços para sincronizar o pipeline e evitar flaky tests.

--- a/documentacao/devops.md
+++ b/documentacao/devops.md
@@ -7,3 +7,11 @@ As seguintes alterações foram implementadas:
 * **Remoção de script de espera:** O serviço `adote-facil-backend` utilizava um script manual, como `command: sh -c "until nc -z..."` para aguardar o banco de dados. Removemos isso, pois o banco já possui um `healthcheck` configurado e o backend utiliza a diretiva nativa `depends_on: condition: service_healthy`, o que torna a espera via script redundante e ineficiente.
 * **Injeção Explícita de Variáveis de Ambiente:** Adicionamos a diretiva `env_file` nos serviços `adote-facil-backend` e `adote-facil-frontend`. É uma boa prática que o orquestrador de contêineres seja o responsável por injetar as variáveis de ambiente, garantindo que o contêiner seja agnóstico ao ambiente em que roda.
 * **Políticas de Resiliência:** Implementamos a política `restart: unless-stopped` em todos os serviços. Isso garante alta disponibilidade, reiniciando os contêineres automaticamente em caso de falhas ou reinicialização do host.
+
+## 2. Otimização do Dockerfile do Backend (`backend/Dockerfile`)
+
+O Dockerfile original do backend apresentava alguns anti-padrões de CI/CD e empacotamento. As seguintes melhorias foram aplicadas:
+
+* **Remoção da execução de testes na build:** A instrução `RUN npm run test` foi removida. A responsabilidade de executar testes e barrar código quebrado pertence à esteira de Integração Contínua (CI), e não ao artefato de build. Isso reduz o tempo de empacotamento e separa as responsabilidades.
+* **Uso de Instalação Determinística:** Substituição do `npm install` por `npm ci`. Isso garante que o Docker instale exatamente as versões das dependências "lockadas" no `package-lock.json`, evitando quebra de builds por atualizações inesperadas de pacotes.
+* **Limpeza de dependências de desenvolvimento:** Adição do comando `RUN npm prune --production` após a etapa de compilação. Isso remove da imagem final bibliotecas usadas apenas em tempo de desenvolvimento, reduzindo o tamanho do contêiner.

--- a/documentacao/devops.md
+++ b/documentacao/devops.md
@@ -1,32 +1,31 @@
-# Análise e Sugestões DevOps
+# Documentação de DevOps e CI/CD - Adote Fácil
 
-## 1. Refatoração do Docker Compose (`docker-compose.yml`)
+  Este documento detalha as melhorias de infraestrutura, empacotamento e integração contínua implementadas no projeto.
 
-As seguintes alterações foram implementadas:
+## 1. Orquestração (`docker-compose.yml`)
 
-* **Remoção de script de espera:** O serviço `adote-facil-backend` utilizava um script manual, como `command: sh -c "until nc -z..."` para aguardar o banco de dados. Removemos isso, pois o banco já possui um `healthcheck` configurado e o backend utiliza a diretiva nativa `depends_on: condition: service_healthy`, o que torna a espera via script redundante e ineficiente.
-* **Injeção Explícita de Variáveis de Ambiente:** Adicionamos a diretiva `env_file` nos serviços `adote-facil-backend` e `adote-facil-frontend`. É uma boa prática que o orquestrador de contêineres seja o responsável por injetar as variáveis de ambiente, garantindo que o contêiner seja agnóstico ao ambiente em que roda.
-* **Políticas de Resiliência:** Implementamos a política `restart: unless-stopped` em todos os serviços. Isso garante alta disponibilidade, reiniciando os contêineres automaticamente em caso de falhas ou reinicialização do host.
+  Removemos a linha `command: sh -c "until nc -z…"` do backend. Como adicionamos a diretiva `depends_on: condition: service_healthy`, o próprio Docker já sabe que deve segurar o backend até o banco de dados carregar 100%.
 
-## 2. Otimização do Dockerfile do Backend (`backend/Dockerfile`)
+  Adicionado `env_file` tanto no serviço do backend quanto no frontend. A responsabilidade de injetar variáveis de ambiente não é da aplicação, mas sim do Docker Compose. Agora, ele lê os arquivos `.env` do lado de fora e injeta as variáveis nativamente no sistema operacional do contêiner.
 
-O Dockerfile original do backend apresentava alguns anti-padrões de CI/CD e empacotamento. As seguintes melhorias foram aplicadas:
+  Adicionada a instrução `restart: unless-stopped` em todos os serviços (banco, backend e frontend) para que o Docker os reinicie automaticamente caso eles caiam.
 
-* **Remoção da execução de testes na build:** A instrução `RUN npm run test` foi removida. A responsabilidade de executar testes e barrar código quebrado pertence à esteira de Integração Contínua (CI), e não ao artefato de build. Isso reduz o tempo de empacotamento e separa as responsabilidades.
-* **Uso de Instalação Determinística:** Substituição do `npm install` por `npm ci`. Isso garante que o Docker instale exatamente as versões das dependências "lockadas" no `package-lock.json`, evitando quebra de builds por atualizações inesperadas de pacotes.
-* **Limpeza de dependências de desenvolvimento:** Adição do comando `RUN npm prune --production` após a etapa de compilação. Isso remove da imagem final bibliotecas usadas apenas em tempo de desenvolvimento, reduzindo o tamanho do contêiner.
+## 2. Empacotamento do Backend (`backend/Dockerfile`)
 
-## 3. Otimização do Dockerfile do Frontend (`frontend/Dockerfile`)
+  Substituímos npm install por npm ci para instalar as dependências exatas do package-lock.json. Isso garante builds mais rápidos e evita que atualizações acidentais quebrem a aplicação no servidor.
+  
+  Retiramos a linha `RUN npm run test`. O Dockerfile serve apenas para empacotar o software, não para homologá-lo. Se o teste falhar no Docker, a imagem nem termina de ser feita. Movemos essa responsabilidade para o pipeline de CI/CD, que é o lugar correto para rodar validações.
 
-o Dockerfile do frontend foi otimizado para produção:
+  Adicionada a linha `RUN npm prune --production`. Ferramentas como TypeScript são pesadas e só servem para o desenvolvedor. O `prune` deleta todo esse "lixo" do desenvolvimento antes de fechar a imagem, reduzindo consideravelmente o peso do contêiner final.
 
-* **Instalação Determinística:** Substituição de `npm install` por `npm ci` para garantir reprodutibilidade das builds.
+## 3. Empacotamento do Frontend (`frontend/Dockerfile`)
 
-Adição do comando `RUN npm prune --production` logo após o passo de build. Removê-las da imagem final reduz drasticamente o peso do contêiner e melhora a segurança e o tempo de deploy.
+  Aplicamos a mesma lógica do backend. Trocamos para `npm ci` para garantir a trava de versões e adicionamos o `npm prune --production` para limpar dependências pesadas de desenvolvimento após o build.
 
+## 4. Pipeline de CI/CD
 
-## 4. Melhorias no Pipeline de CI/CD (`.github/workflows/experimento-ci-cd.yml`)
+  Adicionado o comando `cp ./backend/.env ./frontend/.env`. O pipeline antigo só criava o `.env` para o backend; essa mudança garante que o frontend também receba as variáveis antes do Docker subir.
 
-* **Controle de Versão do Ambiente:** Inclusão do passo `actions/setup-node@v4` para fixar a versão do Node.js (v20), evitando incompatibilidades entre o ambiente do runner e o contêiner de produção.
-* **Correção de Contexto de Execução:** O diretório de trabalho (working directory) dos jobs de integração foi ajustado para a raiz do repositório, refletindo a nova localização do `docker-compose.yml`. A injeção de variáveis `.env` também foi corrigida para abastecer ambos os serviços (backend e frontend).
-* **Espera Inteligente de Contêineres:** Remoção do anti-padrão de temporização manual `sleep 10` no job de testes de integração. Foi implementada a flag `--wait` no `docker compose up`, que aproveita os `healthchecks` nativos dos serviços para sincronizar o pipeline e evitar flaky tests.
+  Adicionamos a flag `--wait` no comando de subida. Isso atrela o pipeline diretamente aos healthchecks do Docker, zerando a chance de o teste falhar por falta de sincronia de tempo.
+
+  Removi a limitação de pasta (`working-directory: ./backend`) do comando do Docker Compose. Como o orquestrador está na raiz do projeto, forçar o pipeline a procurar ele dentro da pasta do backend fazia o teste quebrar na nuvem. Também fixamos o Node.js na versão 20 no pipeline para garantir que o ambiente de teste seja exatamente igual ao de produção.

--- a/documentacao/historias-teste.md
+++ b/documentacao/historias-teste.md
@@ -1,0 +1,125 @@
+# Histórias de Usuário e Cenários de Teste 
+ 
+Cada história de usuário descreve o que ele deseja fazer e por quê, acompanhada de cenários de teste que validam se a experiência ocorre como esperado.
+
+## História de Usuário 1: Cadastro de Novo Usuário
+
+*"Como visitante do site, quero me cadastrar na plataforma para poder anunciar um animal ou iniciar um processo de adoção."*
+
+### Cenários de Teste
+
+- **Cenário Principal: Cadastro realizado com sucesso**
+  1. O visitante acessa a página de cadastro.
+  2. Preenche corretamente os campos obrigatórios.
+  3. O sistema cria a nova conta.
+  4. O usuário é redirecionado para a tela de login ou já entra automaticamente na plataforma.
+
+- **Cenários Alternativos**
+  - **E-mail já em uso**
+    1. O visitante informa um e-mail que já está cadastrado.
+    2. Ao tentar se registrar, o sistema exibe a mensagem de erro.
+  - **Campos obrigatórios em branco**
+    1. O visitante deixa um ou mais campos sem preencher.
+    2. Ao clicar para cadastrar, o sistema destaca os campos faltantes.
+  - **Senha inválida**
+    1. O visitante insere uma senha que não atende aos critérios mínimos.
+    2. O sistema exibe uma mensagem de erro.
+
+## História de Usuário 2: Autenticação de Usuário
+
+*"Como usuário cadastrado, quero fazer login no sistema para ter acesso às minhas informações e funcionalidades restritas."*
+
+### Cenários de Teste
+
+- **Cenário Principal: Login bem-sucedido**
+  1. O usuário acessa a página de login.
+  2. Informa e-mail e senha corretos.
+  3. O sistema autentica e inicia a sessão.
+
+- **Cenários Alternativos**
+  - **Credenciais inválidas**
+    1. O usuário informa dados incorretos.
+    2. O sistema retorna erro com a mensagem de erro.
+  - **Campos em branco**
+    1. O usuário não preenche o e-mail ou a senha.
+    2. O sistema alerta que os campos são obrigatórios.
+
+## História de Usuário 3: Atualização de Perfil
+
+*"Como usuário autenticado, quero atualizar minhas informações de perfil para que meus dados estejam sempre corretos."*
+
+### Cenários de Teste
+
+- **Cenário Principal: Atualização bem-sucedida**
+  1. O usuário acessa sua conta já autenticado.
+  2. Vai até a página de perfil e altera dados como nome, telefone ou e-mail.
+  3. Salva as alterações.
+  4. O sistema confirma a atualização.
+
+- **Cenários Alternativos**
+  - **Token ausente ou inválido**
+    1. A requisição é feita sem autenticação válida.
+    2. O sistema responde com uma mensagem de erro.
+  - **E-mail já cadastrado**
+    1. O usuário tenta alterar o e-mail para um que já está registrado.
+    2. O sistema rejeita e mostra uma mensagem de erro.
+  - **Dados inválidos**
+    1. O usuário insere informações em formato incorreto.
+    2. O sistema não aceita e solicita a correção.
+
+## História de Usuário 4: Anunciar Animal para Adoção
+
+*"Como doador, quero cadastrar um animal com fotos e detalhes para que pessoas interessadas possam encontrá-lo."*
+
+### Cenários de Teste
+
+- **Cenário Principal: Cadastro de animal com sucesso**
+  1. O usuário está autenticado.
+  2. Preenche os dados obrigatórios do animal.
+  3. Anexa fotos válidas.
+  4. Envia o formulário.
+  5. O sistema cria o anúncio e exibe o card do animal.
+
+- **Cenários Alternativos**
+  - **Usuário não autenticado**
+    1. O usuário não está logado.
+    2. Ao tentar cadastrar, o sistema retorna erro de autorização.
+  - **Campos obrigatórios ausentes**
+    1. Informações essenciais não foram preenchidas.
+    2. O sistema indica os campos em falta antes de concluir.
+  - **Upload inválido**
+    1. O usuário anexa arquivos em formato ou tamanho não permitido.
+    2. O sistema rejeita o upload e informa o problema.
+
+## História de Usuário 5: Listar Animais Disponíveis
+
+*"Como visitante ou adotante, quero visualizar os animais disponíveis, com filtros de busca, para encontrar o pet ideal para mim."*
+
+### Cenários de Teste
+
+- **Cenário Principal: Listagem com sucesso**
+  1. Há animais cadastrados no sistema.
+  2. O usuário acessa a página de busca.
+  3. Aplica filtros opcionais.
+  4. O sistema retorna a lista filtrada.
+
+- **Cenário Alternativo**
+  - **Nenhum resultado para os filtros**
+    1. Os critérios não correspondem a nenhum animal.
+    2. O sistema retorna lista vazia.
+
+## História de Usuário 6: Listar Meus Animais
+
+*"Como doador, quero visualizar os animais que cadastrei para gerenciar meus anúncios."*
+
+### Cenários de Teste
+
+- **Cenário Principal: Exibição dos meus anúncios**
+  1. O usuário acessa a área “Meus Animais” estando logado.
+  2. O sistema retorna apenas os animais que ele cadastrou.
+
+- **Cenários Alternativos**
+  - **Usuário sem anúncios**
+    1. O doador ainda não cadastrou nenhum animal.
+    2. O sistema mostra a mensagem *“Você ainda não cadastrou nenhum animal para adoção. Clique aqui para cadastrar."*
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,11 +4,13 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 
-RUN npm install
+RUN npm ci
 
 COPY . .
 
 RUN npm run build
+
+RUN npm prune --production
 
 EXPOSE 3000
 


### PR DESCRIPTION
## 1. Orquestração (`docker-compose.yml`)

 Removemos a linha `command: sh -c "until nc -z…"` do backend. Como adicionamos a diretiva `depends_on: condition: service_healthy`, o próprio Docker já sabe que deve segurar o backend até o banco de dados carregar 100%.

 Adicionado `env_file` tanto no serviço do backend quanto no frontend. A responsabilidade de injetar variáveis de ambiente não é da aplicação, mas sim do Docker Compose. Agora, ele lê os arquivos `.env` do lado de fora e injeta as variáveis nativamente no sistema operacional do contêiner.

 Adicionada a instrução `restart: unless-stopped` em todos os serviços (banco, backend e frontend) para que o Docker os reinicie automaticamente caso eles caiam.

## 2. Empacotamento do Backend (`backend/Dockerfile`)

 Substituímos npm install por npm ci para instalar as dependências exatas do package-lock.json. Isso garante builds mais rápidos e evita que atualizações acidentais quebrem a aplicação no servidor.
  
 Retiramos a linha `RUN npm run test`. O Dockerfile serve apenas para empacotar o software, não para homologá-lo. Se o teste falhar no Docker, a imagem nem termina de ser feita. Movemos essa responsabilidade para o pipeline de CI/CD, que é o lugar correto para rodar validações.

 Adicionada a linha `RUN npm prune --production`. Ferramentas como TypeScript são pesadas e só servem para o desenvolvedor. O `prune` deleta todo esse "lixo" do desenvolvimento antes de fechar a imagem, reduzindo consideravelmente o peso do contêiner final.

## 3. Empacotamento do Frontend (`frontend/Dockerfile`)

 Aplicamos a mesma lógica do backend. Trocamos para `npm ci` para garantir a trava de versões e adicionamos o `npm prune --production` para limpar dependências pesadas de desenvolvimento após o build.

## 4. Pipeline de CI/CD

 Adicionado o comando `cp ./backend/.env ./frontend/.env`. O pipeline antigo só criava o `.env` para o backend; essa mudança garante que o frontend também receba as variáveis antes do Docker subir.

 Adicionamos a flag `--wait` no comando de subida. Isso atrela o pipeline diretamente aos healthchecks do Docker, zerando a chance de o teste falhar por falta de sincronia de tempo.

 Removi a limitação de pasta (`working-directory: ./backend`) do comando do Docker Compose. Como o orquestrador está na raiz do projeto, forçar o pipeline a procurar ele dentro da pasta do backend fazia o teste quebrar na nuvem. Também fixamos o Node.js na versão 20 no pipeline para garantir que o ambiente de teste seja exatamente igual ao de produção.